### PR TITLE
fix: resolve session expiry bug that locks out returning users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## [Unreleased] - Session Expiry & Reliability Fixes
+
+### Fixed
+
+#### CRITICAL - `login_with_passkey` now refreshes `lastLogin` on re-authentication
+- **File:** `spacetimedb/src/index.ts`
+- **Bug:** When a user re-authenticated via passkey and their identity already existed for the same user, `lastLogin` was never updated. This meant that even after a successful re-login, the server-side session remained stale/expired, leaving the user permanently locked out with "Sessao expirada" errors.
+- **Fix:** Added an `else` branch to update `lastLogin` via `ctx.db.UserIdentity.identity.update()` whenever the existing identity matches the authenticating user.
+
+#### HIGH - `extendSession` errors now handled; force re-login on session expiry
+- **File:** `webapp/src/App.tsx`
+- **Bug:** The `extendSession()` reducer was called on reconnect but its returned Promise was never awaited or caught. If the session had expired server-side, the error was silently swallowed and the user appeared "logged in" (subscription data was present) while being unable to perform any action.
+- **Fix:** Added `.catch()` to the `extendSession()` call. On `session_expired` the auth token is cleared and the user is redirected to `/login`.
+
+#### HIGH - Periodic session heartbeat (every 5 minutes)
+- **File:** `webapp/src/App.tsx`
+- **Bug:** `extendSession()` was called only once per connection transition. With no periodic keep-alive, the server-side session could expire while the user was actively using the app (e.g. tab left open for extended periods).
+- **Fix:** Added a `setInterval` that calls `extendSession()` every 5 minutes while the user is online and logged in. The interval is properly cleaned up on disconnect/logout. Also handles session expiry mid-heartbeat.
+
+#### MEDIUM - Removed debug `console.log` from `UserIdentitySelfView`
+- **File:** `spacetimedb/src/schema.ts`
+- **Bug:** A `console.log("UserIdentitySelfView", ctx.sender, ui)` statement was left in the view definition, causing server log spam on every subscription evaluation for every connected client.
+- **Fix:** Removed the `console.log` call.
+
+#### MEDIUM - Removed redundant `VenueMember` query in `send_message`
+- **File:** `spacetimedb/src/index.ts`
+- **Bug:** The `send_message` reducer queried `VenueMember.venue_member_venue_id.filter(ch.venueId)` twice to find the caller's membership. The second query (`myVenueMembership`) was unnecessary since the identical result was already stored in `member`.
+- **Fix:** Replaced `myVenueMembership?.role.tag` with `member.role.tag`, eliminating the duplicate database scan.

--- a/spacetimedb/src/index.ts
+++ b/spacetimedb/src/index.ts
@@ -507,13 +507,21 @@ export const login_with_passkey = spacetimedb.reducer(
       throw new SenderError("api_errors.invalid_signature");
     }
 
-    // 7. Link identity
+    // 7. Link identity and refresh session
     const existingIdentity = ctx.db.UserIdentity.identity.find(ctx.sender);
     if (!existingIdentity || existingIdentity.userId !== expectedUser.userId) {
+      // Identity is new or belongs to a different user — replace it
       if (existingIdentity) ctx.db.UserIdentity.identity.delete(ctx.sender);
       ctx.db.UserIdentity.insert({
         identity: ctx.sender,
         userId: expectedUser.userId,
+        lastLogin: ctx.timestamp,
+      });
+    } else {
+      // Same identity + same user — still refresh lastLogin so the session
+      // does not remain stale after a long absence.
+      ctx.db.UserIdentity.identity.update({
+        ...existingIdentity,
         lastLogin: ctx.timestamp,
       });
     }
@@ -1026,11 +1034,9 @@ export const send_message = spacetimedb.reducer(
       throw new SenderError("api_errors.blocked_from_sending");
     }
 
-    const myVenueMembership = [...ctx.db.VenueMember.venue_member_venue_id.filter(ch.venueId)].find(m => m.userId === userId);
-
     const myChannelRoleRow = [...ctx.db.ChannelMemberRole.channel_member_role_channel_id.filter(channelId)].find(r => r.userId === userId);
     const userRole = myChannelRoleRow?.role.tag;
-    const isOwner = myVenueMembership?.role.tag === "owner" || userRole === "owner";
+    const isOwner = member.role.tag === "owner" || userRole === "owner";
 
     if (!isOwner && userRole !== "admin" && userRole !== "moderator") {
       throw new SenderError("api_errors.send_message_forbidden");

--- a/spacetimedb/src/schema.ts
+++ b/spacetimedb/src/schema.ts
@@ -336,7 +336,6 @@ export const UserView = spacetimedb.view({ name: "user_view", public: true }, t.
 export const UserIdentitySelfView = spacetimedb.view({ name: "user_identity_self_view", public: true }, t.array(UserIdentity.rowType), (ctx) => {
   if (!ctx.sender) return [];
   const ui = ctx.db.UserIdentity.identity.find(ctx.sender);
-  console.log("UserIdentitySelfView", ctx.sender, ui);
   return ui ? [ui] : [];
 });
 

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { useEffect, useRef } from 'react';
+import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import { useReducer } from 'spacetimedb/react';
 import { reducers } from './module_bindings';
 import { SpacetimeDBProvider } from './SpacetimeDBProvider';
@@ -35,13 +35,42 @@ function AppContent() {
   const { status, nextRetryIn, reconnect, connectionError, isInitialLoad } = useConnectivity();
   const { isLoggedIn } = useAuth();
   const extendSession = useReducer(reducers.extendSession);
+  const navigate = useNavigate();
+  const extendSessionRef = useRef(extendSession);
+  extendSessionRef.current = extendSession;
 
-  // Extend session on mount/re-connect if logged in
+  // Extend session on mount/re-connect if logged in; on failure force re-login
   useEffect(() => {
-    if (status === 'online' && isLoggedIn) {
-      extendSession();
-    }
-  }, [status, isLoggedIn, extendSession]);
+    if (status !== 'online' || !isLoggedIn) return;
+
+    extendSession().catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('session_expired')) {
+        console.warn('[STDB] Session expired on extend, forcing re-login.');
+        localStorage.removeItem('auth_token');
+        navigate('/login', { replace: true });
+      }
+    });
+  }, [status, isLoggedIn, extendSession, navigate]);
+
+  // Periodic heartbeat – keeps the server-side session alive while the tab is open
+  useEffect(() => {
+    if (status !== 'online' || !isLoggedIn) return;
+
+    const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+    const id = setInterval(() => {
+      extendSessionRef.current().catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('session_expired')) {
+          console.warn('[STDB] Session expired during heartbeat, forcing re-login.');
+          localStorage.removeItem('auth_token');
+          navigate('/login', { replace: true });
+        }
+      });
+    }, HEARTBEAT_INTERVAL_MS);
+
+    return () => clearInterval(id);
+  }, [status, isLoggedIn, navigate]);
 
   // Show the friendly overlay for BOTH initial loading and reconnection
   if (status !== 'online') {


### PR DESCRIPTION
## Problem

A user reported a popup error when trying to send a message after being away from the app for some time. After a thorough code review, I found a **critical session management bug** that not only causes this error but leaves the user permanently locked out with no way to recover without clearing browser data.

### Root Cause

When a user re-authenticates via login_with_passkey and their identity already exists for the same user, lastLogin was **never updated**. This means:

1. User is active, lastLogin = T1
2. User is away for an extended period
3. Server-side session expires (
ow > lastLogin + 30 days)
4. User returns and re-authenticates via passkey
5. login_with_passkey skips the lastLogin update (identity already exists for same user)
6. Session **remains expired** even after successful re-authentication
7. Any reducer call (e.g. send_message) throws \session_expired\
8. User is stuck in an unrecoverable expired session state

Additionally, extendSession() was called without error handling, so the expiry was silently ignored, and there was no periodic keep-alive to prevent expiry during active use.

---

## Changes

### CRITICAL - \login_with_passkey\ now refreshes \lastLogin\ on re-authentication
**File:** \spacetimedb/src/index.ts\

Added an \else\ branch so that when the existing identity matches the authenticating user, \lastLogin\ is updated via \ctx.db.UserIdentity.identity.update()\. This ensures re-authentication always refreshes the session timestamp.

### HIGH - \extendSession\ errors now handled; force re-login on session expiry
**File:** \webapp/src/App.tsx\

Added \.catch()\ to the \extendSession()\ call. On \session_expired\, the auth token is cleared from \localStorage\ and the user is redirected to \/login\ instead of silently failing while the UI appears functional.

### HIGH - Periodic session heartbeat (every 5 minutes)
**File:** \webapp/src/App.tsx\

Added a \setInterval\ that calls \extendSession()\ every 5 minutes while the user is online and logged in. This keeps the server-side session alive during extended active use. The interval is properly cleaned up on disconnect/logout.

### MEDIUM - Removed debug \console.log\ from \UserIdentitySelfView\
**File:** \spacetimedb/src/schema.ts\

Removed a leftover \console.log\ that was spamming server logs on every subscription evaluation for every connected client.

### MEDIUM - Removed redundant \VenueMember\ query in \send_message\
**File:** \spacetimedb/src/index.ts\

The \send_message\ reducer queried \VenueMember\ twice with the same filter. Replaced the duplicate \myVenueMembership\ variable with the already-resolved \member\ variable.

---

## Testing

- [x] \login_with_passkey\ now updates \lastLogin\ when identity exists for same user
- [x] \extendSession\ failure on reconnect triggers redirect to \/login\
- [x] Periodic heartbeat calls \extendSession\ every 5 minutes
- [x] Session expiry during heartbeat triggers redirect to \/login\
- [x] No regressions in other reducer flows (code review)